### PR TITLE
Changing what README says about the repo directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Other install options on Mac may also work well.
 You can put it wherever you like:
 
     $ git clone https://github.com/yosinski/deep-visualization-toolbox
-    $ cd deep_visualization_toolbox
+    $ cd deep-visualization-toolbox
 
 Copy `settings.py.template` to `settings.py` and edit it so the `caffevis_caffe_root` variable points to the directory where you've compiled caffe in Step 1:
 


### PR DESCRIPTION
I think the directory cited in the README for the repo might have a typo. The directory is specified as `deep_visualization_toolbox`, when I believe it's actually `deep-visualization-toolbox`. Basically, the directory should have hyphens and not underscores. 

Totally trivial and not important, but perhaps not useless. 